### PR TITLE
fix(youtube-embed): add required iframe attributes for playback

### DIFF
--- a/src/adapters/youtube.js
+++ b/src/adapters/youtube.js
@@ -114,14 +114,6 @@ export default class YouTubeAdapter extends BaseAdapter {
     let videoIframe = this.createIframe(src);
     let iframeId = videoIframe.id;
 
-    // Add YouTube-specific iframe attributes
-    videoIframe.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
-
-    // Get existing allow permissions from base iframe and append web-share
-    let existingAllow = videoIframe.getAttribute('allow') || '';
-    let allowPermissions = existingAllow ? existingAllow + '; web-share' : 'web-share';
-    videoIframe.setAttribute('allow', allowPermissions);    
-
     document.body.appendChild(videoIframe);
 
     this.player = new YT.Player(iframeId, {

--- a/src/adapters/youtube.js
+++ b/src/adapters/youtube.js
@@ -114,6 +114,14 @@ export default class YouTubeAdapter extends BaseAdapter {
     let videoIframe = this.createIframe(src);
     let iframeId = videoIframe.id;
 
+    // Add YouTube-specific iframe attributes
+    videoIframe.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
+
+    // Get existing allow permissions from base iframe and append web-share
+    let existingAllow = videoIframe.getAttribute('allow') || '';
+    let allowPermissions = existingAllow ? existingAllow + '; web-share' : 'web-share';
+    videoIframe.setAttribute('allow', allowPermissions);    
+
     document.body.appendChild(videoIframe);
 
     this.player = new YT.Player(iframeId, {


### PR DESCRIPTION
YouTube recently updated its embed policy to require specific iframe attributes — referrerpolicy and allow="web-share" — for embedded videos.

Without these attributes, embedded videos fail to load or play correctly. This policy change caused all YouTube embeds to stop working on LinkedIn.

The iframe configuration is managed through the player-iframe library, so this PR updates the library to include the required attributes.

|Before|After|
|:-:|:-:|
|<img width="1840" height="1191" alt="yt-before" src="https://github.com/user-attachments/assets/2147a38a-ba5e-4ad7-a7b3-19adb81f4018" />|<img width="1840" height="1191" alt="yt-after" src="https://github.com/user-attachments/assets/36e71343-e0d2-4d2d-b46f-0c35db879ff7" />|